### PR TITLE
Fixing README to include the now required go-fuzz-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ FuzzyVM creates state tests that can be used to differential fuzz EVM implementa
 It only focus on the test generation part, the test execution is handled by [goevmlab](https://github.com/holiman/goevmlab).
 
 ## Environment
-You need to have golang, go-fuzz and go-fuzz-build installed
+You need to have golang, go-fuzz, go-fuzz-build, and go-ethereum installed
 
 ## Install instructions
 
@@ -16,12 +16,10 @@ git clone git@github.com:MariusVanDerWijden/FuzzyVM.git
 cd FuzzyVM
 # Build the binary
 go build
-# Create `fuzzer-fuzz.zip`
-cd fuzzer
-go-fuzz-build
-cd ..
 # Create the fuzz-test generator as follows:
 ./FuzzyVM build
+# Create an initial corpus
+./FuzzyVM corpus --count 100  
 # Run the fuzzer
 ./FuzzyVM run
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ FuzzyVM creates state tests that can be used to differential fuzz EVM implementa
 It only focus on the test generation part, the test execution is handled by [goevmlab](https://github.com/holiman/goevmlab).
 
 ## Environment
-You need to have golang and go-fuzz installed
+You need to have golang, go-fuzz and go-fuzz-build installed
 
 ## Install instructions
 
@@ -16,6 +16,10 @@ git clone git@github.com:MariusVanDerWijden/FuzzyVM.git
 cd FuzzyVM
 # Build the binary
 go build
+# Create `fuzzer-fuzz.zip`
+cd fuzzer
+go-fuzz-build
+cd ..
 # Create the fuzz-test generator as follows:
 ./FuzzyVM build
 # Run the fuzzer


### PR DESCRIPTION
Hi,

Apparently go-fuzz has changed over the years. It now needs the set of steps as I describe in the updated README. This has been tested on my machine, and works.

Thanks for looking into this,

Mate