### PR TITLE
build: fix building on apple silicon

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,8 @@ func build(c *cli.Context) error {
 	cmd.Stderr = os.Stderr
 	// We have to disable CGO
 	cgo := "CGO_ENABLED=0"
-	env := append(os.Environ(), cgo)
+	goarch := "GOARCH=amd64" // on Apple Silicon, the build fails with GOARCH=arm64
+	env := append(os.Environ(), cgo, goarch)
 	cmd.Env = env
 	return cmd.Run()
 }

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"runtime"
 
 	"github.com/urfave/cli/v2"
 
@@ -138,8 +139,12 @@ func build(c *cli.Context) error {
 	cmd.Stderr = os.Stderr
 	// We have to disable CGO
 	cgo := "CGO_ENABLED=0"
-	goarch := "GOARCH=amd64" // on Apple Silicon, the build fails with GOARCH=arm64
-	env := append(os.Environ(), cgo, goarch)
+	env := append(os.Environ(), cgo)
+	// on Apple Silicon, the build fails with GOARCH=arm64
+	if runtime.GOARCH == "arm64" {
+		goarch := "GOARCH=amd64"
+		env = append(env, goarch)
+	}
 	cmd.Env = env
 	return cmd.Run()
 }


### PR DESCRIPTION
Hi, while I was exploring the FuzzyVM I've encountered this error:

```go
./FuzzyVM build

/Users/USER/go/pkg/mod/github.com/ethereum/go-ethereum@v1.11.5/crypto/blake2b/blake2b_f_fuzz.go:43:2: undefined: fSSE4
/Users/USER/go/pkg/mod/github.com/ethereum/go-ethereum@v1.11.5/crypto/blake2b/blake2b_f_fuzz.go:48:2: undefined: fAVX
/Users/USER/go/pkg/mod/github.com/ethereum/go-ethereum@v1.11.5/crypto/blake2b/blake2b_f_fuzz.go:53:2: undefined: fAVX2
typechecking of . failed
exit status 1
```
I am on Apple Silicon, which is causing the issue so I've included a fix. 
